### PR TITLE
Added Additional check to checkVersion as an Integer.

### DIFF
--- a/src/net/h31ix/updater/Updater.java
+++ b/src/net/h31ix/updater/Updater.java
@@ -494,7 +494,7 @@ public class Updater
             if(title.split("v").length == 2)
             {
                 String remoteVersion = title.split("v")[1].split(" ")[0]; // Get the newest file's version number
-                int remVer = 0,curVer=0;
+                int remVer = -1,curVer=0;
                 try
                 {
                     remVer = calVer(remoteVersion);
@@ -502,7 +502,7 @@ public class Updater
                 }
                 catch(NumberFormatException nfe)
                 {
-                //Do nothing. 
+                remVer=-1;
                 }
                 if(hasTag(version)||version.equalsIgnoreCase(remoteVersion)||curVer>=remVer)
                 {
@@ -534,7 +534,7 @@ public class Updater
             for (int i = 0; i <s.length(); i++) 
             {
                 Character c = s.charAt(i);
-                if (Character.isDigit(c)) 
+                if (Character.isLetterOrDigit(c)) 
                 {
                     sb.append(c);
                 }


### PR DESCRIPTION
I found an issue when testing one of my plugins. Added Additional check to check version string as an Integer. Example:

Major.Minor.Build
BukkitDev Version 1.0.2
Current Version 1.1.3

113>102
!!Don't download and overwrite every time.

I wrote the first commit out as a test. Which failed for a null character. Currently latest commit works perfectly when changing the version string in the plugin.yml above or below the version saved to bukkitDev.
