### PR TITLE
fix pluginname conflict, if pluginname contains a 'v'

### DIFF
--- a/src/net/h31ix/updater/Updater.java
+++ b/src/net/h31ix/updater/Updater.java
@@ -491,9 +491,9 @@ public class Updater
         if(type != UpdateType.NO_VERSION_CHECK)
         {
             String version = plugin.getDescription().getVersion();
-            if(title.split("v").length == 2)
+            if(title.split(" v").length == 2)
             {
-                String remoteVersion = title.split("v")[1].split(" ")[0]; // Get the newest file's version number
+                String remoteVersion = title.split(" v")[1].split(" ")[0]; // Get the newest file's version number
                 int remVer = -1,curVer=0;
                 try
                 {


### PR DESCRIPTION
fix pluginname conflict
if pluginname contains a 'v', Updater doesn't work

e.g.
the length of the split("v") Array from  my Addon "DragonAntiPvPLeaver v.1.5" is 4 and not 2 
