### PR TITLE
Exclude versions labeled with -SNAPSHOT from the update check

### DIFF
--- a/src/net/h31ix/updater/Updater.java
+++ b/src/net/h31ix/updater/Updater.java
@@ -54,7 +54,7 @@ public class Updater
     private File file; // The plugin's file
     private Thread thread; // Updater thread
     private static final String DBOUrl = "http://dev.bukkit.org/server-mods/"; // Slugs will be appended to this to get to the project's RSS feed
-    private String [] noUpdateTag = {"-DEV","-PRE"}; // If the version number contains one of these, don't update.
+    private String [] noUpdateTag = {"-DEV","-PRE","-SNAPSHOT"}; // If the version number contains one of these, don't update.
     private static final int BYTE_SIZE = 1024; // Used for downloading files
     private String updateFolder = YamlConfiguration.loadConfiguration(new File("bukkit.yml")).getString("settings.update-folder"); // The folder that downloads will be placed in
     private Updater.UpdateResult result = Updater.UpdateResult.SUCCESS; // Used for determining the outcome of the update process


### PR DESCRIPTION
Maven projects are often labeled with a x.x.x-SNAPSHOT as the version, since they are development builds they shouldn't call the update check.

Additional resource:
Maven documentation (http://maven.apache.org/guides/getting-started/index.html)
"[...] Maven goes a long way to help you with version management and you will often see the SNAPSHOT designator in a version, which indicates that a project is in a state of development. [...]"
