### PR TITLE
Update DBOUrl to new standard

### DIFF
--- a/src/net/h31ix/updater/Updater.java
+++ b/src/net/h31ix/updater/Updater.java
@@ -53,7 +53,7 @@ public class Updater
     private URL url; // Connecting to RSS
     private File file; // The plugin's file
     private Thread thread; // Updater thread
-    private static final String DBOUrl = "http://dev.bukkit.org/server-mods/"; // Slugs will be appended to this to get to the project's RSS feed
+    private static final String DBOUrl = "http://dev.bukkit.org/bukkit-plugins/"; // Slugs will be appended to this to get to the project's RSS feed
     private String [] noUpdateTag = {"-DEV","-PRE","-SNAPSHOT"}; // If the version number contains one of these, don't update.
     private static final int BYTE_SIZE = 1024; // Used for downloading files
     private String updateFolder = YamlConfiguration.loadConfiguration(new File("bukkit.yml")).getString("settings.update-folder"); // The folder that downloads will be placed in


### PR DESCRIPTION
DBO now uses bukkit-plugins in it's URLs, this change will prevent issues if the redirection from server-mods is removed in the future
