### PR TITLE
Add missing '&' in announce logic

### DIFF
--- a/src/net/h31ix/updater/Updater.java
+++ b/src/net/h31ix/updater/Updater.java
@@ -222,7 +222,7 @@ public class Updater
                 downloaded += count;
                 fout.write(data, 0, count);
                 int percent = (int) (downloaded * 100 / fileLength);
-                if(announce & (percent % 10 == 0))
+                if(announce && (percent % 10 == 0))
                 {
                     plugin.getLogger().info("Downloading update: " + percent + "% of " + fileLength + " bytes.");
                 }


### PR DESCRIPTION
The short circuit and is better in this case so you don't need to evaluate both expressions. If announce == false, it no longer needs to check if percent % 10 == 0.
