### PR TITLE
Return an unknown release type if getting failed

### DIFF
--- a/src/main/java/net/gravitydevelopment/updater/Updater.java
+++ b/src/main/java/net/gravitydevelopment/updater/Updater.java
@@ -145,7 +145,11 @@ public class Updater {
         /**
          * A "release" file.
          */
-        RELEASE
+        RELEASE,
+        /**
+         * A file with an unknown release type.
+         */
+        UNKNOWN
     }
 
     /**
@@ -246,7 +250,7 @@ public class Updater {
                 }
             }
         }
-        return null;
+        return ReleaseType.UNKNOWN;
     }
 
     /**


### PR DESCRIPTION
Returning null is a silly idea. With this commit, it returns ReleaseType.UNKNOWN.