### PR TITLE
Add a passive Callback functionality to the updater.

### DIFF
--- a/src/main/java/net/gravitydevelopment/updater/Updater.java
+++ b/src/main/java/net/gravitydevelopment/updater/Updater.java
@@ -274,8 +274,12 @@ public class Updater {
             this.result = UpdateResult.FAIL_BADID;
         }
 
-        this.thread = new Thread(new UpdateRunnable());
-        this.thread.start();
+        if (this.result != UpdateResult.FAIL_BADID) {
+            this.thread = new Thread(new UpdateRunnable());
+            this.thread.start();
+        } else {
+            runUpdater();
+        }
     }
 
     /**


### PR DESCRIPTION
The callback will be notified (on the main thread) when an update check has finished, regardless of the result.

This allows for custom messages, etc. to be processed on the main thread without blocking the server.
