### PR TITLE
Fix paragraph tag in javadoc

### DIFF
--- a/src/main/java/net/gravitydevelopment/updater/Updater.java
+++ b/src/main/java/net/gravitydevelopment/updater/Updater.java
@@ -18,13 +18,13 @@ import org.json.simple.JSONValue;
 
 /**
  * Check for updates on BukkitDev for a given plugin, and download the updates if needed.
- * <p/>
+ * <p>
  * <b>VERY, VERY IMPORTANT</b>: Because there are no standards for adding auto-update toggles in your plugin's config, this system provides NO CHECK WITH YOUR CONFIG to make sure the user has allowed auto-updating.
  * <br>
  * It is a <b>BUKKIT POLICY</b> that you include a boolean value in your config that prevents the auto-updater from running <b>AT ALL</b>.
  * <br>
  * If you fail to include this option in your config, your plugin will be <b>REJECTED</b> when you attempt to submit it to dev.bukkit.org.
- * <p/>
+ * </p>
  * An example of a good configuration option would be something similar to 'auto-update: true' - if this value is set to false you may NOT run the auto-updater.
  * <br>
  * If you are unsure about these rules, please read the plugin submission guidelines: http://goo.gl/8iU5l


### PR DESCRIPTION
Gradle was throwing an error during build because of these incorrect paragraph tags:


![ss 2015-01-23 at 10 59 37](https://cloud.githubusercontent.com/assets/1383438/5886057/95e275e4-a353-11e4-8168-b8a583bc04ed.png)