### PR TITLE
Support for more complex file name

### DIFF
--- a/src/main/java/net/gravitydevelopment/updater/Updater.java
+++ b/src/main/java/net/gravitydevelopment/updater/Updater.java
@@ -555,9 +555,9 @@ public class Updater {
         final String title = this.versionName;
         if (this.type != UpdateType.NO_VERSION_CHECK) {
             final String localVersion = this.plugin.getDescription().getVersion();
-            if (title.split(DELIMETER).length == 2) {
+            if (title.split(DELIMETER).length >= 2) {
                 // Get the newest file's version number
-                final String remoteVersion = title.split(DELIMETER)[1].split(" ")[0];
+                final String remoteVersion = title.split(DELIMETER)[title.split(DELIMETER).length - 1].split(" ")[0];
 
                 if (this.hasTag(localVersion) || !this.shouldUpdate(localVersion, remoteVersion)) {
                     // We already have the latest version, or this build is tagged for no-update


### PR DESCRIPTION
Added support for files which name contains many words, like "super new update vVERSION". Only last part contains information about version and all else are file name. It's solved problem with files which name starts on 'v'. For better performance, object "title.split(DELIMETER).lenght-1" might be alocated once as a new String[].