### PR TITLE
Update to properly handle 301/302 redirects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.gravitydevelopment.updater</groupId>
     <artifactId>updater</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
     <packaging>jar</packaging>
     <name>Updater</name>
     <url>http://forums.bukkit.org/threads/updater-2-0-easy-safe-and-policy-compliant-auto-updating-for-your-plugins-new.96681/</url>

--- a/src/main/java/net/gravitydevelopment/updater/Updater.java
+++ b/src/main/java/net/gravitydevelopment/updater/Updater.java
@@ -1,6 +1,7 @@
 package net.gravitydevelopment.updater;
 
 import java.io.*;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -30,7 +31,7 @@ import org.json.simple.JSONValue;
  * If you are unsure about these rules, please read the plugin submission guidelines: http://goo.gl/8iU5l
  *
  * @author Gravity
- * @version 2.3
+ * @version 2.4
  */
 
 public class Updater {
@@ -390,7 +391,7 @@ public class Updater {
         BufferedInputStream in = null;
         FileOutputStream fout = null;
         try {
-            URL fileUrl = new URL(this.versionLink);
+            URL fileUrl = followRedirects(this.versionLink);
             final int fileLength = fileUrl.openConnection().getContentLength();
             in = new BufferedInputStream(fileUrl.openStream());
             fout = new FileOutputStream(new File(this.updateFolder, file.getName()));
@@ -428,6 +429,33 @@ public class Updater {
                 this.plugin.getLogger().log(Level.SEVERE, null, ex);
             }
         }
+    }
+
+    private URL followRedirects(String location) throws IOException {
+        URL resourceUrl, base, next;
+        HttpURLConnection conn;
+        String redLoc;
+        while (true) {
+            resourceUrl = new URL(location);
+            conn = (HttpURLConnection) resourceUrl.openConnection();
+
+            conn.setConnectTimeout(15000);
+            conn.setReadTimeout(15000);
+            conn.setInstanceFollowRedirects(false);
+            conn.setRequestProperty("User-Agent", "Mozilla/5.0...");
+
+            switch (conn.getResponseCode()) {
+                case HttpURLConnection.HTTP_MOVED_PERM:
+                case HttpURLConnection.HTTP_MOVED_TEMP:
+                    redLoc = conn.getHeaderField("Location");
+                    base = new URL(location);
+                    next = new URL(base, redLoc);  // Deal with relative URLs
+                    location = next.toExternalForm();
+                    continue;
+            }
+            break;
+        }
+        return conn.getURL();
     }
 
     /**


### PR DESCRIPTION
This PR adds code to properly follow 301/302 redirects while downloading artifacts. This is vital given the recent change to CurseForge's CDN which causes _all_ download links to return a 301 response.
